### PR TITLE
adds 6-api-patch-reviews functionality and error handling

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -67,7 +67,7 @@ describe('GET /api/reviews/:reviewid', () => {
         .get(`/api/reviews/${REVIEW_ID}`)
         .expect(404)
         .then(({ body }) => {
-            expect(body.msg).toBe('Review Not Found')
+            expect(body.msg).toBe(`Review ${REVIEW_ID} Not Found`)
         })
     })
     it('400: responds with error when user requests invalid id data type', () => {
@@ -85,7 +85,6 @@ describe('GET /api/users', () => {
         .get('/api/users')
         .expect(200)
         .then(({ body }) => {
-            console.log(body, '<--- whats this')
             expect(Array.isArray(body.users)).toBe(true);
             expect(body.users.length).toBe(4);
             body.users.forEach((user) => {
@@ -95,6 +94,96 @@ describe('GET /api/users', () => {
                     avatar_url: expect.any(String)
                 })
             })
+        })
+    })
+})
+
+describe('PATCH /api/reviews/:reviewid', () => {
+    it('200: should update a review object with an updated votes total when passed an increment votes object with a value of 1', () => {
+        const REVIEW_ID = 1
+        const newVote = 1
+        const reviewUpdates = {
+            inc_votes: newVote
+          }
+        return request(app)
+        .patch(`/api/reviews/${REVIEW_ID}`)
+        .send(reviewUpdates)
+        .expect(200)
+        .then(({body}) => {
+            expect(typeof body).toBe('object')
+            expect(body).toHaveProperty('title', expect.any(String))
+            expect(body).toHaveProperty('designer', expect.any(String))
+            expect(body).toHaveProperty('owner', expect.any(String))
+            expect(body).toHaveProperty('review_img_url', expect.any(String))
+            expect(body).toHaveProperty('review_body', expect.any(String))
+            expect(body).toHaveProperty('category', expect.any(String))
+            expect(body).toHaveProperty('created_at', expect.any(String))
+            expect(body).toHaveProperty('votes', expect.any(Number))
+            expect(body).toHaveProperty('review_id', expect.any(Number))
+            expect(body.votes).toBe(2)
+        })
+    })
+    it('200: should update a review object with an updated votes total when passed an increment votes object with a value of -100', () => {
+        const REVIEW_ID = 1
+        const newVote = -100
+        const reviewUpdates = {
+            inc_votes: newVote
+          }
+        return request(app)
+        .patch(`/api/reviews/${REVIEW_ID}`)
+        .send(reviewUpdates)
+        .expect(200)
+        .then(({body}) => {
+            expect(typeof body).toBe('object')
+            expect(body).toHaveProperty('title', expect.any(String))
+            expect(body).toHaveProperty('designer', expect.any(String))
+            expect(body).toHaveProperty('owner', expect.any(String))
+            expect(body).toHaveProperty('review_img_url', expect.any(String))
+            expect(body).toHaveProperty('review_body', expect.any(String))
+            expect(body).toHaveProperty('category', expect.any(String))
+            expect(body).toHaveProperty('created_at', expect.any(String))
+            expect(body).toHaveProperty('votes', expect.any(Number))
+            expect(body).toHaveProperty('review_id', expect.any(Number))
+            expect(body.votes).toBe(-99)
+        })
+    })
+    it('400: responds with error if inc_votes value is an invalid data type', () => {
+        const REVIEW_ID = 1
+        const newVote = 'great game!'
+        const reviewUpdates = {
+            inc_votes: newVote
+          }
+        return request(app)
+        .patch(`/api/reviews/${REVIEW_ID}`)
+        .send(reviewUpdates)
+        .expect(400)
+        .then(({body}) => {
+            expect(body.msg).toBe('please enter a number!')
+        })
+    })
+    it('404: responds with error if requested review_id is currently unused', () => {
+        const REVIEW_ID = 2352
+        const newVote = 2
+        const reviewUpdates = {
+            inc_votes: newVote
+          }
+        return request(app)
+        .patch(`/api/reviews/${REVIEW_ID}`)
+        .send(reviewUpdates)
+        .expect(404)
+        .then(({ body }) => {
+            expect(body.msg).toBe(`Review ${REVIEW_ID} Not Found`)
+        })
+    })
+    it('400: responds with error if passed object is empty', () => {
+        const REVIEW_ID = 1
+        const reviewUpdates = {}
+        return request(app)
+        .patch(`/api/reviews/${REVIEW_ID}`)
+        .send(reviewUpdates)
+        .expect(400)
+        .then(({body}) => {
+            expect(body.msg).toBe('please enter a number!')
         })
     })
 })

--- a/app.js
+++ b/app.js
@@ -1,16 +1,19 @@
 const { response } = require('express');
 const express = require('express')
 const { getCategories } = require('./controllers/categories.controllers')
-const { getReviewById } = require('./controllers/reviews.controllers')
+const { getReviewById, patchReviewById } = require('./controllers/reviews.controllers')
 const { getUsers } = require('./controllers/users.controllers')
 
 const app = express();
+app.use(express.json())
 
 app.get('/api/categories', getCategories);
 
 app.get('/api/reviews/:reviewid', getReviewById)
 
 app.get('/api/users', getUsers)
+
+app.patch('/api/reviews/:reviewid', patchReviewById)
 
 // handle custom errors
 
@@ -19,19 +22,12 @@ app.all('/*', (req, res, next) => {
 } )
 
 app.use((err, req, res, next) => {
+    console.log('are we in here')
     if (err.status && err.msg) {
         res.status(err.status).send({
             msg: err.msg })
     } else {
             next(err)
-    }
-})
-
-app.use((err, req, res, next) => {
-    if (err.status && err.msg) {
-        res.status(err.status).send({ msg: err.msg })
-    } else {
-        next(err)
     }
 })
 

--- a/controllers/reviews.controllers.js
+++ b/controllers/reviews.controllers.js
@@ -1,14 +1,23 @@
-const { selectReviewById } = require('../models/reviews.models')
+const { selectReviewById, updateReviewById } = require('../models/reviews.models')
 
 exports.getReviewById = (req, res, next) => {
     selectReviewById(req.params.reviewid)
     .then((reviews) => {
-        if (reviews === undefined) {
-            return Promise.reject({ status: 404, msg: 'Review Not Found'})
-        } 
         res.send({ reviews });
     })
     .catch((err) => {
         next(err)
     });
+}
+
+exports.patchReviewById = (req, res, next) => {
+    const updates = req.body
+    const id = req.params.reviewid
+    updateReviewById(id, updates)
+    .then((rows) => {
+        res.status(200).send(rows)
+    })
+    .catch((err) => {
+        next(err)
+    })
 }

--- a/models/reviews.models.js
+++ b/models/reviews.models.js
@@ -4,6 +4,24 @@ exports.selectReviewById = (reviewid) => {
     return db
     .query('SELECT * FROM reviews WHERE review_id=$1;', [reviewid])
     .then(({ rows }) => {
+        if (rows.length === 0) {
+            return Promise.reject({ status: 404, msg: `Review ${reviewid} Not Found`})
+        } 
            return rows[0];
+        })
+}
+
+exports.updateReviewById = (reviewid, reviewUpdates) => {
+    const { inc_votes } = reviewUpdates;
+    if (typeof inc_votes !== 'number') {
+        return Promise.reject({ status: 400, msg: 'please enter a number!' })
+    }
+    return db
+        .query(`UPDATE reviews SET votes = votes + $1 WHERE review_id=$2 RETURNING*;`, [inc_votes, reviewid])
+        .then(({ rows }) => {
+            if (rows.length === 0) {
+                return Promise.reject({ status: 404, msg: `Review ${reviewid} Not Found`})
+            } 
+        return rows[0]
         })
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "pg-format": "^1.0.4"
       },
       "devDependencies": {
-        "husky": "^7.0.0",
+        "husky": "^7.0.4",
         "jest": "^27.5.1",
         "jest-extended": "^2.0.0",
         "supertest": "^6.2.4"

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "pg-format": "^1.0.4"
   },
   "devDependencies": {
-    "husky": "^7.0.0",
+    "husky": "^7.0.4",
     "jest": "^27.5.1",
     "jest-extended": "^2.0.0",
     "supertest": "^6.2.4"


### PR DESCRIPTION
completes patch alongside three different error handling tests

I could only figure out how to implement the incorrect data types in the inc_votes object test in the model, so I moved a previous test from the controller to the model to maintain consistency