### PR TITLE
complete ticket 12 with error handling

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -3,6 +3,7 @@ const seed = require('../db/seeds/seed');
 const testData = require('../db/data/test-data/index.js');
 const app = require('../app');
 const request = require('supertest');
+const { getCommentById } = require('../controllers/comments.controllers');
 
 beforeEach(() => {
     return seed(testData)
@@ -40,6 +41,7 @@ describe('GET /api/categories', () => {
         })
     })
 })
+
 describe('GET /api/reviews', () => {
     it('200: returns an array of review objects', () => {
         return request(app)
@@ -529,6 +531,43 @@ describe('PATCH /api/reviews/:reviewid', () => {
         .expect(400)
         .then(({body}) => {
             expect(body.msg).toBe('you need an inc_votes key!')
+        })
+    })
+})
+
+describe('DELETE /api/comments/:commentid', () => {
+    it('204: responds with empty response body and comment is no longer in database after DELETE is completed', () => {
+        const COMMENT_ID = 3
+        return request(app)
+        .delete(`/api/comments/${COMMENT_ID}`)
+        .expect(204)
+        .then(({ body }) => {
+            expect(body).toEqual({})
+            const COMMENT_ID = 3
+            return request(app)
+            .get(`/api/comments/${COMMENT_ID}`)
+            .expect(404)
+            .then(({ body }) => {
+                expect(body.msg).toBe(`Comment ${COMMENT_ID} Not Found`)
+            })
+        })
+    })
+    it('404: responds with error if user tries to delete a comment that does not exist', () => {
+        const COMMENT_ID = 5432
+        return request(app)
+        .delete(`/api/comments/${COMMENT_ID}`)
+        .expect(404)
+        .then(({ body }) => {
+            expect(body.msg).toBe('that comment does not exist!')
+        })
+    })
+    it('400: responds with error if user tries to delete a comment using an incorrect data type', () => {
+        const COMMENT_ID = 'wallaby'
+        return request(app)
+        .delete(`/api/comments/${COMMENT_ID}`)
+        .expect(400)
+        .then(({ body }) => {
+            expect(body.msg).toBe('Bad Request')
         })
     })
 })

--- a/app.js
+++ b/app.js
@@ -2,7 +2,7 @@ const { response } = require('express');
 const express = require('express')
 const { getCategories } = require('./controllers/categories.controllers')
 const { getReviews, getReviewById, patchReviewById } = require('./controllers/reviews.controllers')
-const { getCommentsByReviewId, postCommentByReviewId } = require('./controllers/comments.controllers')
+const { getCommentsByReviewId, postCommentByReviewId, deleteComment, getCommentById } = require('./controllers/comments.controllers')
 const { getUsers } = require('./controllers/users.controllers')
 
 const app = express();
@@ -21,6 +21,10 @@ app.get('/api/users', getUsers)
 app.post('/api/reviews/:reviewid/comments', postCommentByReviewId)
 
 app.patch('/api/reviews/:reviewid', patchReviewById)
+
+app.get('/api/comments/:commentid', getCommentById)
+
+app.delete('/api/comments/:commentid', deleteComment)
 
 // handle custom errors
 

--- a/controllers/comments.controllers.js
+++ b/controllers/comments.controllers.js
@@ -24,7 +24,7 @@ exports.deleteComment = (req, res, next) => {
     const commentToDelete = req.params.commentid
     removeComment(commentToDelete)
     .then((comment) => {
-        res.status(204).send({comment})
+        res.status(204).send({})
     })
     .catch((err) => {
         next(err)

--- a/controllers/comments.controllers.js
+++ b/controllers/comments.controllers.js
@@ -1,4 +1,4 @@
-const { selectCommentsByReviewId, insertComment } = require('../models/comments.models')
+const { selectCommentsByReviewId, insertComment, removeComment, selectCommentById } = require('../models/comments.models')
 
 exports.getCommentsByReviewId = (req, res, next) => {
     selectCommentsByReviewId(req.params.reviewid)
@@ -18,4 +18,25 @@ exports.postCommentByReviewId = (req, res, next) => {
     .catch((err) => {
         next(err)
     })
+}
+
+exports.deleteComment = (req, res, next) => {
+    const commentToDelete = req.params.commentid
+    removeComment(commentToDelete)
+    .then((comment) => {
+        res.status(204).send({comment})
+    })
+    .catch((err) => {
+        next(err)
+    })
+}
+
+exports.getCommentById = (req, res, next) => {
+    selectCommentById(req.params.commentid)
+    .then((reviews) => {
+        res.send({ reviews });
+    })
+    .catch((err) => {
+        next(err)
+    });
 }

--- a/models/comments.models.js
+++ b/models/comments.models.js
@@ -55,3 +55,30 @@ exports.insertComment = (newComment) => {
             })
         })
 }
+
+exports.removeComment = (comment_id) => {
+    let numberOfComments = 0;
+    return db
+        .query(`SELECT comment_id FROM comments`)
+        .then((result) => {
+            numberOfComments = result.rows.length
+        }).then(() => {
+            return db
+                .query(`DELETE FROM comments WHERE review_id=$1;`, [comment_id])
+                .then((result) => {
+                    if (comment_id > numberOfComments) return Promise.reject({ status: 404, msg: `that comment does not exist!`})
+                    return result.rows[0]
+                })
+        })
+}
+
+exports.selectCommentById = (commentid) => {
+    return db
+    .query(`SELECT * FROM comments WHERE comments.comment_id=$1;`, [commentid])
+    .then(({ rows }) => {
+        if (rows.length === 0) {
+            return Promise.reject({ status: 404, msg: `Comment ${commentid} Not Found`})
+        } 
+            return rows[0];
+        })
+}

--- a/models/comments.models.js
+++ b/models/comments.models.js
@@ -67,7 +67,6 @@ exports.removeComment = (comment_id) => {
                 .query(`DELETE FROM comments WHERE review_id=$1;`, [comment_id])
                 .then((result) => {
                     if (comment_id > numberOfComments) return Promise.reject({ status: 404, msg: `that comment does not exist!`})
-                    return result.rows[0]
                 })
         })
 }


### PR DESCRIPTION
completes ticket 12

in order to successfully test that the deleted comment was no longer in the database, I created a get /api/comments/:commentid function and called that within the tests

added error handling for the user attempting to delete a comment that does not exist and if they decide they're going to try and delete a comment called wallaby rather than using the correct data type. you can't take these users seriously sometimes

I also added a comprehensive test for ticket 11 on Lee's advice to test for multiple queries in a single URL